### PR TITLE
chore: remove SetBreadingStatus

### DIFF
--- a/FarmProject.Application/BreedingRabbitsService/BreedingRabbitService.cs
+++ b/FarmProject.Application/BreedingRabbitsService/BreedingRabbitService.cs
@@ -64,7 +64,7 @@ public class BreedingRabbitService(IUnitOfWork unitOfWork) : IBreedingRabbitServ
         if (requestBreedingRabbit == null)
             return Result.Failure<BreedingRabbit>(BreedingRabbitErrors.NotFound);
 
-        requestBreedingRabbit.SetBreedingStatus(breedingStatus);
+        requestBreedingRabbit.BreedingStatus = breedingStatus;
 
         var updatedBreedingRabbit = await _unitOfWork.BreedingRabbitRepository.UpdateAsync(requestBreedingRabbit);
 

--- a/FarmProject.Domain.UnitTests/PairTest/RecordFailedImpregnation.cs
+++ b/FarmProject.Domain.UnitTests/PairTest/RecordFailedImpregnation.cs
@@ -12,7 +12,7 @@ public class RecordFailedImpregnation
         var rabbitFemale = new BreedingRabbit("Mary");
         var endPairingDate = DateTime.Today;
 
-        rabbitFemale.SetBreedingStatus(BreedingStatus.Paired);
+        rabbitFemale.BreedingStatus = BreedingStatus.Paired;
 
         var pair = new Pair(rabbitMaleId, rabbitFemale, endPairingDate);
 
@@ -35,7 +35,7 @@ public class RecordFailedImpregnation
         var rabbitFemale = new BreedingRabbit("Mary");
         var endPairingDate = DateTime.Today;
 
-        rabbitFemale.SetBreedingStatus(BreedingStatus.Paired);
+        rabbitFemale.BreedingStatus = BreedingStatus.Paired;
 
         var pair = new Pair(rabbitMaleId, rabbitFemale, endPairingDate);
 

--- a/FarmProject.Domain.UnitTests/PairTest/RecordSuccessfulImpregnation.cs
+++ b/FarmProject.Domain.UnitTests/PairTest/RecordSuccessfulImpregnation.cs
@@ -13,7 +13,7 @@ namespace FarmProject.Domain.UnitTests.PairTest
             var rabbitFemale = new BreedingRabbit("Mary");
             var endPairingDate = DateTime.Today;
 
-            rabbitFemale.SetBreedingStatus(BreedingStatus.Paired);
+            rabbitFemale.BreedingStatus = BreedingStatus.Paired;
 
             var pair = new Pair(rabbitMaleId, rabbitFemale, endPairingDate);
 
@@ -36,7 +36,7 @@ namespace FarmProject.Domain.UnitTests.PairTest
             var rabbitFemale = new BreedingRabbit("Mary");
             var endPairingDate = DateTime.Today;
 
-            rabbitFemale.SetBreedingStatus(BreedingStatus.Paired);
+            rabbitFemale.BreedingStatus = BreedingStatus.Paired;
 
             var pair = new Pair(rabbitMaleId, rabbitFemale, endPairingDate);
 

--- a/FarmProject.Domain/Models/BreedingRabbit.cs
+++ b/FarmProject.Domain/Models/BreedingRabbit.cs
@@ -3,15 +3,18 @@ using FarmProject.Domain.Constants;
 using FarmProject.Domain.Events;
 
 namespace FarmProject.Domain.Models;
+
 public class BreedingRabbit(string name) : Entity
 {
     public string Name { get; private set; } = name;
-    public BreedingStatus BreedingStatus { get; private set; } = BreedingStatus.Available;
+    
+    public BreedingStatus BreedingStatus { get; set; } = BreedingStatus.Available;
+
     public int? CageId { get; set; }
 
     public Result Breed(int maleId, DateTime dateTimeNow)
     {
-        SetBreedingStatus(BreedingStatus.Paired);
+        BreedingStatus = BreedingStatus.Paired;
 
         AddDomainEvent(new BreedEvent()
             { 
@@ -22,7 +25,4 @@ public class BreedingRabbit(string name) : Entity
 
         return Result.Success();
     }
-
-    public void SetBreedingStatus(BreedingStatus breedingStatus)
-        => BreedingStatus = breedingStatus;
 }

--- a/FarmProject.Domain/Models/Pair.cs
+++ b/FarmProject.Domain/Models/Pair.cs
@@ -51,7 +51,7 @@ public class Pair : Entity
         if (PairingStatus != PairingStatus.Active)
             return Result.Failure(PairErrors.InvalidStateChange);
 
-        FemaleRabbit!.SetBreedingStatus(BreedingStatus.Available);
+        FemaleRabbit!.BreedingStatus = BreedingStatus.Available;
 
         PairingStatus = PairingStatus.Failed;
 
@@ -65,7 +65,7 @@ public class Pair : Entity
         if (PairingStatus != PairingStatus.Active)
             return Result.Failure(PairErrors.InvalidStateChange);
 
-        FemaleRabbit!.SetBreedingStatus(BreedingStatus.Pregnant);
+        FemaleRabbit!.BreedingStatus = BreedingStatus.Pregnant;
 
         PairingStatus = PairingStatus.Successful;
 


### PR DESCRIPTION
I don't see a reason for `SetBreadingStatus`. It performs the same role as the setter on `BreadingStatus` property.